### PR TITLE
get the pattern from the environment variable

### DIFF
--- a/src/main/java/com/edw/config/CustomConsoleAppender.java
+++ b/src/main/java/com/edw/config/CustomConsoleAppender.java
@@ -18,6 +18,9 @@ public class CustomConsoleAppender extends AppenderBase<ILoggingEvent> {
 
     private SimpleDateFormat simpleDateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
 
+    String defaultPattern = "(.*Authorization:|.*Content-Type:) .*\"";
+    String replacement = "$1 xxx\"";
+
     public CustomConsoleAppender() {
         super();
         start();
@@ -25,9 +28,10 @@ public class CustomConsoleAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     public void append(ILoggingEvent iLoggingEvent) {
-
+	String value = System.getenv("MASK_PATTERN");
+        String pattern =  value != null ? value : defaultPattern;
         String modifiedFormattedMessage = iLoggingEvent.getFormattedMessage();
-        modifiedFormattedMessage = modifiedFormattedMessage.replaceAll("(\"Authorization.*$)", "\"Authorization: xxxxx\"");
+        modifiedFormattedMessage = modifiedFormattedMessage.replaceAll(pattern, "$1 xxx\"");
 
         System.out.println(
                 simpleDateFormat.format(new Date()) + " [" +

--- a/src/main/java/com/edw/config/CustomConsoleAppender.java
+++ b/src/main/java/com/edw/config/CustomConsoleAppender.java
@@ -31,7 +31,7 @@ public class CustomConsoleAppender extends AppenderBase<ILoggingEvent> {
 	String value = System.getenv("MASK_PATTERN");
         String pattern =  value != null ? value : defaultPattern;
         String modifiedFormattedMessage = iLoggingEvent.getFormattedMessage();
-        modifiedFormattedMessage = modifiedFormattedMessage.replaceAll(pattern, "$1 xxx\"");
+        modifiedFormattedMessage = modifiedFormattedMessage.replaceAll(pattern, replacement);
 
         System.out.println(
                 simpleDateFormat.format(new Date()) + " [" +

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
     <appender name="CUSTOM-HTTP-CONSOLE"
               class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %replace(%msg){"(\"Authorization.*$)", "\"Authorization: xxxxx\""}%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %replace(%msg){"(.*Authorization.*|.*Content-Type:) .*\"", "$1 xxxxx\""}%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
@@ -29,7 +29,7 @@
     </logger>
 
     <logger name="org.apache.hc.client5.http.wire" level="DEBUG" additivity="false">
-        <appender-ref ref="CUSTOM-HTTP-CONSOLE-2" />
+        <appender-ref ref="CUSTOM-HTTP-CONSOLE" />
     </logger>
 
     <root level="INFO">


### PR DESCRIPTION
- type in terminal:

`export MASK_PATTERN='(.*Authorization:|.*Content-Type:) .*"'`

- then run test:

`mvn test |tee out.log`

- then verify the logs

`grep "xxx" out.log`

- You should get a result like this:

```
14:03:13.633 [main] DEBUG org.apache.hc.client5.http.wire - http-outgoing-0 >> "Content-Type: xxx"
14:03:13.772 [main] DEBUG org.apache.hc.client5.http.wire - http-outgoing-0 << "Content-Type: xxx"
14:03:13.792 [main] DEBUG org.apache.hc.client5.http.wire - http-outgoing-1 >> "Authorization: xxx"
14:03:13.808 [main] DEBUG org.apache.hc.client5.http.wire - http-outgoing-2 >> "Content-Type: xxx"
14:03:13.814 [main] DEBUG org.apache.hc.client5.http.wire - http-outgoing-2 << "Content-Type: xxx"
```